### PR TITLE
check typeof this.cachedWordList[i] (string)

### DIFF
--- a/main.js
+++ b/main.js
@@ -71,7 +71,7 @@ define(function (require, exports, module) {
         if(symbolBeforeCursorArray){
             // find if the half-word inputed is in the list
             for(var i in this.cachedWordList){
-                if(this.cachedWordList[i].indexOf(symbolBeforeCursorArray[0])==0){
+                if(typeof this.cachedWordList[i] === 'string' && this.cachedWordList[i].indexOf(symbolBeforeCursorArray[0])==0){
                     return true;  
                 }
             }
@@ -111,7 +111,7 @@ define(function (require, exports, module) {
         var symbolBeforeCursorArray = textBeforeCursor.match(this.currentTokenDefinition);
         var hintList = [];
         for(var i in this.cachedWordList){
-            if(this.cachedWordList[i].indexOf(symbolBeforeCursorArray[0])==0){
+            if(typeof this.cachedWordList[i] === 'string' && this.cachedWordList[i].indexOf(symbolBeforeCursorArray[0])==0){
                 hintList.push(this.cachedWordList[i]);
             }
         }


### PR DESCRIPTION
I sometimes get an error that there is no indexOf function for a function
![brackets-wp-hint](https://cloud.githubusercontent.com/assets/4931746/5662481/cc5abecc-9739-11e4-8977-c4b59b64997c.png)

which kind of only happens when I use my own extension FuncDocr :/ but I could resolve it inside your extension and have no idea why this happens only when I use my bascially unrelated extension...

https://github.com/Wikunia/brackets-FuncDocr/issues/23#issuecomment-69148722