### PR TITLE
Set the cursor position inside the parenthesis

### DIFF
--- a/main.js
+++ b/main.js
@@ -138,6 +138,13 @@ define(function (require, exports, module) {
         var indexOfTheSymbol = textBeforeCursor.search(this.currentTokenDefinition);
         var replaceStart = {line:cursor.line,ch:indexOfTheSymbol};
         this.editor.document.replaceRange(hint, replaceStart, cursor);
+        
+        if(hint.slice(-1) === ")") {
+            cursor = this.editor.getCursorPos();
+            cursor.ch--;
+            this.editor.setCursorPos(cursor);
+        }
+        
         return false;
     };
     


### PR DESCRIPTION
I changed the cursor position to inside of the parenthesis after replacement of the text. This way is more easy when it's needed write the parameters.
